### PR TITLE
Added moving structures functionality

### DIFF
--- a/doc/ProjectManager.md
+++ b/doc/ProjectManager.md
@@ -157,6 +157,33 @@ project.layers;                 // -> {layerName: [Structure, ...], ...}
 project.layers[layerName];      // -> [Structure, ...]
 ```
 
+### Moving Structures
+
+One can change the layer a structure is attached to:
+
+```javascript
+project.setStructureLayer(structure, layerName);
+project.setStructureLayer(structureID, layerName);
+```
+
+The structure will be added to the end of the new layer, or not moved at all if the structure is already on the target layer.
+* `layerName` is **optional**. If it is not provided, the structure will be moved to a layer called `"default"`.
+
+A structure can also be moved easily within a layer:
+
+```javascript
+project.moveStructure(structure, delta);
+project.moveStructure(structureID, delta);
+project.setStructureIndex(structure, index);
+project.setStructureIndex(structureID, index);
+```
+
+* `moveStructure` will change the index of the structure in its current layer relatively to its current index.
+  * `delta` is a relative number. Using a negative number moves the structure closer to the front of its current layer.
+* `setStructureIndex` is the absolute version of `moveStructure`. Passing a negative `index` means from the end of the layer. `-1` being the last index.
+
+__NOTE:__ For all these functions, the layer is certified not to be left with holes. This means that moving a structure to an index bigger than the current layer's size will result in the structure being moved to the end of it.
+
 ### Adding Layers
 
 Layers are automatically added when you add a structure to an unexisting layer, but you can also add them manually:

--- a/lib/ProjectManager.js
+++ b/lib/ProjectManager.js
@@ -177,6 +177,73 @@ var ProjectManager = SerializableClass.$extend({
         structure.$data._layerName = undefined;
     },
 
+    /**
+     * Change the structure's current layer.
+     *
+     * @method setStructureLayer
+     * @param {Structure|String} structure
+     * @param {String} layerName
+     */
+    setStructureLayer: function(structure, layerName) {
+        structure = (typeof structure === "string") ? this.$data.structures[structure] : structure;
+        if (!(structure instanceof Structure) || structure.$data._layerName === layerName) {
+            return;
+        }
+
+        var layer = structure.layer;
+        layer.splice(layer.indexOf(structure), 1);
+
+        layerName = layerName || "default";
+        this.addLayers(layerName);
+        var targetLayer = this.$data.layers[layerName];
+        targetLayer.push(structure);
+        structure.$data._layerName = layerName;
+    },
+
+    /**
+     * Change the structure's position within its layer relatively to its current position.
+     *
+     * @method moveStructure
+     * @param {Structure|String} structure
+     * @param {Number} delta
+     */
+    moveStructure: function(structure, delta) {
+        structure = (typeof structure === "string") ? this.$data.structures[structure] : structure;
+        if (!(structure instanceof Structure)) {
+            return;
+        }
+
+        var index = structure.layer.indexOf(structure) + delta;
+        this.setStructureIndex(structure, (index < 0) ? 0 : index);
+    },
+
+    /**
+     * Change the structure's position within its layer to the specified index.
+     *
+     * @method setStructureIndex
+     * @param {Structure|String} structure
+     * @param {Number} index
+     */
+    setStructureIndex: function(structure, index) {
+        structure = (typeof structure === "string") ? this.$data.structures[structure] : structure;
+        if (!(structure instanceof Structure)) {
+            return;
+        }
+
+        var layer = structure.layer;
+        if (index < 0) {
+            index = Math.max(layer.length + index, 0);
+        }
+        else {
+            index = Math.min(index, layer.length - 1);
+        }
+
+        // Remove current and add to new
+        layer.splice(layer.indexOf(structure), 1);
+        layer.splice(index, 0, structure);
+
+    },
+
     saveAsBuffer: function() {
         this.$data.wprjFile.project = this.serialize();
         return this.$data.wprjFile.exportAsBlob();

--- a/test/ProjectManager.js
+++ b/test/ProjectManager.js
@@ -193,6 +193,60 @@ describe("ProjectManager", function() {
             expect(project.structures).to.be.empty();
         });
 
+        it("can move a structure to another layer", function() {
+            var project = new ProjectManager();
+            var structure = new Structure();
+            project.addStructure(structure);
+
+            project.setStructureLayer(structure, "foo");
+            expect(structure.layer).to.be(project.layers.foo);
+            expect(project.layers.default).to.be.empty();
+
+            project.setStructureLayer(structure);
+            expect(structure.layer).to.be(project.layers.default);
+            expect(project.layers.foo).to.be.empty();
+        });
+
+        it("can change a structure's index within its layer", function() {
+            var project = new ProjectManager();
+            var structureA = new Structure();
+            var structureB = new Structure();
+            var structureC = new Structure();
+            project.addStructure(structureA);
+            project.addStructure(structureB);
+            project.addStructure(structureC);
+
+            project.moveStructure(structureA, 1);
+            expect(project.layers.default[0]).to.be(structureB);
+            expect(project.layers.default[1]).to.be(structureA);
+            expect(project.layers.default[2]).to.be(structureC);
+
+            project.moveStructure(structureC, -2);
+            expect(project.layers.default[0]).to.be(structureC);
+            expect(project.layers.default[1]).to.be(structureB);
+            expect(project.layers.default[2]).to.be(structureA);
+
+            project.setStructureIndex(structureA, 1);
+            expect(project.layers.default[0]).to.be(structureC);
+            expect(project.layers.default[1]).to.be(structureA);
+            expect(project.layers.default[2]).to.be(structureB);
+
+            project.setStructureIndex(structureB, -2);
+            expect(project.layers.default[0]).to.be(structureC);
+            expect(project.layers.default[1]).to.be(structureB);
+            expect(project.layers.default[2]).to.be(structureA);
+
+            project.setStructureIndex(structureC, 5);
+            expect(project.layers.default[0]).to.be(structureB);
+            expect(project.layers.default[1]).to.be(structureA);
+            expect(project.layers.default[2]).to.be(structureC);
+
+            project.setStructureIndex(structureA, -5);
+            expect(project.layers.default[0]).to.be(structureA);
+            expect(project.layers.default[1]).to.be(structureB);
+            expect(project.layers.default[2]).to.be(structureC);
+        });
+
     });
 
     describe("OPEN / SAVE", function() {


### PR DESCRIPTION
### Moving Structures

One can change the layer a structure is attached to:

```javascript
project.setStructureLayer(structure, layerName);
project.setStructureLayer(structureID, layerName);
```

The structure will be added to the end of the new layer, or not moved at all if the structure is already on the target layer.
* `layerName` is **optional**. If it is not provided, the structure will be moved to a layer called `"default"`.

A structure can also be moved easily within a layer:

```javascript
project.moveStructure(structure, delta);
project.moveStructure(structureID, delta);
project.setStructureIndex(structure, index);
project.setStructureIndex(structureID, index);
```

* `moveStructure` will change the index of the structure in its current layer relatively to its current index.
  * `delta` is a relative number. Using a negative number moves the structure closer to the front of its current layer.
* `setStructureIndex` is the absolute version of `moveStructure`. Passing a negative `index` means from the end of the layer. `-1` being the last index.

__NOTE:__ For all these functions, the layer is certified not to be left with holes. This means that moving a structure to an index bigger than the current layer's size will result in the structure being moved to the end of it.
