### PR TITLE
History

### DIFF
--- a/doc/History.md
+++ b/doc/History.md
@@ -1,0 +1,50 @@
+# obsidian-project: History
+
+`History` is a class that helps managing over-time changes of a project. Features:
+
+* A run-time history binded to a specific project-manager.
+* Take snapshots of the current state of a project.
+* Go back and forth into the history.
+* Changes are applied through a diff, so only properties that have changed are reset.
+
+Example:
+
+```javascript
+var History = require("obsidian-project/lib/History");
+
+var history = new History(project, {
+    maxLength: 20   // How many snapshots at most (depth of the history stack)
+});
+
+history.snapshot(); // Save initial state of our project
+
+// Our project changes, we save this new state
+project.addStructure(structure, "foo");
+structure.x = 42;
+history.snapshot();
+
+history.back();     // Revert back to initial state (structure not in project)
+history.forward();  // Cancel revert (structure.x is now 42)
+```
+
+
+## Snapshots
+
+Taking snapshots is at the heart of the History. This is up to the developer to do a `history.snapshot()` whenever a significant change has occured across the project.
+
+```javascript
+history.snapshot();
+history.clear();    // Remove all stored snapshots 
+```
+
+__NOTE:__ Project metadata are not saved into the snapshots. Blobs are only saved as references, and therefore any changes to their inner data are not stored.
+
+
+## Navigating
+
+```javascript
+history.back();
+history.forward();
+history.go(-3);     // Similar in result to three history.back() in a row
+history.go(4);      // Similar in result to four history.forward() in a row
+```

--- a/doc/ProjectManager.md
+++ b/doc/ProjectManager.md
@@ -1,6 +1,6 @@
 # obsidian-project: ProjectManager
 
-`ProjectManager` is an class that can manage a project. Features:
+`ProjectManager` is a class that can manage a project. Features:
 
 * Save a project as a Wanadev Project Format file (WPRJ),
 * Load a save project from a WPRJ file,

--- a/lib/History.js
+++ b/lib/History.js
@@ -94,8 +94,8 @@ var History = Class.$extend({
         this._pointer -= delta;
         var snapshot = this._snapshots[this._pointer];
 
-        // We create create these looking tables to be efficient in searching
-        var structuresCache = this._getStructuresCache(this._pm);
+        // We create these looking tables to be efficient in searching
+        var structuresCache = this._pm.$data.structures;
         var snapshotStructuresCache = this._getStructuresCache(snapshot);
 
         // Remove all structures that should not exist
@@ -118,24 +118,16 @@ var History = Class.$extend({
             for (var i = 0; i < snapshotLayer.length; i++) {
                 var snapshotStructure = snapshotLayer[i];
                 var structure = structuresCache[snapshotStructure.id];
-                var layer = structure.getLayer();
 
-                // Change the layer if moved
-                if (structure.$data._layerName !== layerName) {
-                    layer.splice(layer.indexOf(structure), 1);
-                    layer = this._pm.$data.layers[layerName];
-                    layer.push(structure);
-                    structure.$data._layerName = layerName;
-                }
+                // Change the layer if moved and reorder it anyway
+                this._pm.setStructureLayer(snapshotStructure.id, layerName);
+                this._pm.setStructureIndex(snapshotStructure.id, i);
 
                 // Apply structure data
-                // TODO This apply should become a diff that will occur only on properties that are different
+                // TODO This full unserialization should become a diff that will occur only on properties that are different
                 structure.unserialize(snapshotStructure);
             }
         }
-
-        // Final reordering
-        // FIXME
     },
 
     /**

--- a/lib/History.js
+++ b/lib/History.js
@@ -5,96 +5,119 @@ var Class = require("abitbol");
 /**
  * @class History
  * @constructor
+ * @param {ProjectManager} projectManager
  * @param {Object} params
- * @param {Number} params.level Max amount of snapshots.
+ * @param {Number} params.maxLength Max amount of snapshots.
  */
 var History = Class.$extend({
 
-    __init__: function(params) {
+    __init__: function(projectManager, params) {
+        if (!projectManager) {
+            throw new Error("History needs a project manager to bind to.");
+        }
+
         // Initialisation
         params = params || {};
-        this.$data.level = params.level || 0;
-        this.$data.snapshotsCount = 0;
+        this.$data.maxLength = params.maxLength || 0;
+        this._snapshots = [];
+        this._pointer = -1;
     },
 
     /**
      * Max amount of snapshots stored by the history.
      *
-     * @property level
+     * @property maxLength
      * @type {Number}
      */
-    getLevel: function() {
-        return this.$data.level;
+    getMaxLength: function() {
+        return this.$data.maxLength;
     },
 
-    setLevel: function(level) {
-        this.$data.level = level;
+    setMaxLength: function(maxLength) {
+        this.$data.maxLength = maxLength;
+
+        // Remove older snapshots if any
+        if (this._snapshots.length > maxLength) {
+            var backIndex = Math.max(this._pointer + 1, maxLength);
+            var headIndex = backIndex - maxLength;
+            this._snapshots.splice(backIndex, this._snapshots.length);
+            this._snapshots.splice(0, headIndex);
+            this._pointer -= headIndex;
+        }
     },
 
     /**
      * Currently stored snapshots count.
      *
-     * @property snapshotsCount
+     * @property length
+     * @readOnly
      * @type {Number}
      */
-    getSnapshotsCount: function() {
-        return this.$data.snapshotCount;
-    },
-
-    setSnapshotsCount: function(snapshotCount) {
-        this.$data.snapshotCount = snapshotCount;
+    getLength: function() {
+        return this._snapshots.length;
     },
 
     /**
-     * Currently selected snapshot.
+     * Take a snapshot of the current state of the project and put it into the history.
+     * This snapshot will become the new head, all upbranch ones will be removed.
      *
-     * @method getSnapshot
-     * @return {Object|null} The current snapshot.
+     * @method snapshot
      */
-    getSnapshot: function() {
+    snapshot: function() {
         throw new Error("Not implemented yet");
     },
 
     /**
-     * Save the provided snapshot into the history.
+     * Go backwards or forwards in history.
+     * Positive delta is forwards, negative is backwards.
+     * This will change the current project to the saved version.
      *
-     * @method saveSnapshot
-     * @param {Object} snapshot
+     * @method go
+     * @param {Number} delta
      */
-    saveSnapshot: function(snapshot) {
+    go: function(delta) {
+        delta = (delta !== undefined) ? delta : -1;
         throw new Error("Not implemented yet");
     },
 
     /**
      * Go backwards in history.
      *
-     * @method undoSnapshot
-     * @param {Number} amount How many snapshots to undo.
-     * @return {Object|null} The new current snapshot.
+     * @method back
      */
-    undoSnapshot: function(amount) {
-        amount = amount || 1;
-        throw new Error("Not implemented yet");
+    back: function() {
+        return this.go(-1);
     },
 
     /**
      * Go forwards in history.
      *
-     * @method redoSnapshot
-     * @param {Number} amount How many snapshots to redo.
-     * @return {Object|null} The new current snapshot.
+     * @method forward
      */
-    redoSnapshot: function(amount) {
-        amount = amount || 1;
+    forward: function() {
+        return this.go(1);
+    },
+
+    /**
+     * Test the delta reachability with go.
+     * Returns the effective delta that will occur.
+     * Therefore, a return value of 0 means nothing will change.
+     *
+     * @method try
+     * @param {Number} delta
+     * @return {Number} Effective delta that will occur.
+     */
+    try: function(delta) {
+        delta = (delta !== undefined) ? delta : -1;
         throw new Error("Not implemented yet");
     },
 
     /**
      * Remove all snapshots from history.
      *
-     * @method clearSnapshots
+     * @method clear
      */
-    clearSnapshots: function() {
+    clear: function() {
         throw new Error("Not implemented yet");
     }
 

--- a/lib/History.js
+++ b/lib/History.js
@@ -132,9 +132,15 @@ var History = Class.$extend({
                 this._pm.setStructureLayer(snapshotStructure.id, layerName);
                 this._pm.setStructureIndex(snapshotStructure.id, i);
 
-                // Apply structure data
-                // TODO This full unserialization should become a diff that will occur only on properties that are different
-                structure.unserialize(snapshotStructure);
+                // Apply structure data for properties that have changed
+                for (var propName in snapshotStructure) {
+                    var snapshotProp = snapshotStructure[propName];
+                    var prop = serializer.objectSerializer(structure[propName]);
+                    if (!lodash.isEqual(snapshotProp, prop)) {
+                        structure[propName] = serializer.objectUnserializer(snapshotProp);
+                    }
+                }
+
             }
         }
     },

--- a/lib/History.js
+++ b/lib/History.js
@@ -1,0 +1,103 @@
+"use strict";
+
+var Class = require("abitbol");
+
+/**
+ * @class History
+ * @constructor
+ * @param {Object} params
+ * @param {Number} params.level Max amount of snapshots.
+ */
+var History = Class.$extend({
+
+    __init__: function(params) {
+        // Initialisation
+        params = params || {};
+        this.$data.level = params.level || 0;
+        this.$data.snapshotsCount = 0;
+    },
+
+    /**
+     * Max amount of snapshots stored by the history.
+     *
+     * @property level
+     * @type {Number}
+     */
+    getLevel: function() {
+        return this.$data.level;
+    },
+
+    setLevel: function(level) {
+        this.$data.level = level;
+    },
+
+    /**
+     * Currently stored snapshots count.
+     *
+     * @property snapshotsCount
+     * @type {Number}
+     */
+    getSnapshotsCount: function() {
+        return this.$data.snapshotCount;
+    },
+
+    setSnapshotsCount: function(snapshotCount) {
+        this.$data.snapshotCount = snapshotCount;
+    },
+
+    /**
+     * Currently selected snapshot.
+     *
+     * @method getSnapshot
+     * @return {Object|null} The current snapshot.
+     */
+    getSnapshot: function() {
+        throw new Error("Not implemented yet");
+    },
+
+    /**
+     * Save the provided snapshot into the history.
+     *
+     * @method saveSnapshot
+     * @param {Object} snapshot
+     */
+    saveSnapshot: function(snapshot) {
+        throw new Error("Not implemented yet");
+    },
+
+    /**
+     * Go backwards in history.
+     *
+     * @method undoSnapshot
+     * @param {Number} amount How many snapshots to undo.
+     * @return {Object|null} The new current snapshot.
+     */
+    undoSnapshot: function(amount) {
+        amount = amount || 1;
+        throw new Error("Not implemented yet");
+    },
+
+    /**
+     * Go forwards in history.
+     *
+     * @method redoSnapshot
+     * @param {Number} amount How many snapshots to redo.
+     * @return {Object|null} The new current snapshot.
+     */
+    redoSnapshot: function(amount) {
+        amount = amount || 1;
+        throw new Error("Not implemented yet");
+    },
+
+    /**
+     * Remove all snapshots from history.
+     *
+     * @method clearSnapshots
+     */
+    clearSnapshots: function() {
+        throw new Error("Not implemented yet");
+    }
+
+});
+
+module.exports = History;

--- a/lib/History.js
+++ b/lib/History.js
@@ -91,7 +91,7 @@ var History = Class.$extend({
      * @param {Number} delta
      */
     go: function(delta) {
-        delta = this.try(delta);
+        delta = this.simulate(delta);
         if (delta === 0) {
             return;
         }
@@ -168,11 +168,11 @@ var History = Class.$extend({
      * Returns the effective delta that will occur.
      * Therefore, a return value of 0 means nothing will change.
      *
-     * @method try
+     * @method simulate
      * @param {Number} delta
      * @return {Number} Effective delta that will occur.
      */
-    try: function(delta) {
+    simulate: function(delta) {
         delta = (delta !== undefined) ? delta : -1;
         if (this._pointer < 0) {
             return 0;

--- a/lib/History.js
+++ b/lib/History.js
@@ -27,6 +27,7 @@ var History = Class.$extend({
         this._pm = pm;
         this._snapshots = [];
         this._pointer = -1;
+        this._blobsCount = {};
     },
 
     /**
@@ -79,12 +80,17 @@ var History = Class.$extend({
     snapshot: function() {
         var snapshot = {};
         snapshot.layers = serializer.objectSerializer(this._pm.layers);
+        snapshot.blobCache = this._copyObject(this._pm.$data.blobCache);
+        snapshot.blobList = this._copyObject(this._pm.$data.wprjFile.$data.blobs);
         this._snapshots.splice(0, this._pointer, snapshot);
         this._pointer = 0;
 
-        if (this._snapshots.length > this.$data.maxLength) {
-            this._snapshots.length = this.$data.maxLength;
+        for (var id in snapshot.blobCache) {
+            this._blobsCount[id] = this._blobsCount[id] || 0;
+            this._blobsCount[id] += 1;
         }
+
+        this._cropLength();
     },
 
     /**
@@ -103,6 +109,10 @@ var History = Class.$extend({
 
         this._pointer -= delta;
         var snapshot = this._snapshots[this._pointer];
+
+        // Reapplying blobs
+        this._pm.$data.wprjFile.$data.blobs = this._copyObject(snapshot.blobList);
+        this._pm.$data.blobCache = this._copyObject(snapshot.blobCache);
 
         // We create these looking tables to be efficient in searching
         var structuresCache = this._pm.$data.structures;
@@ -217,9 +227,49 @@ var History = Class.$extend({
         return cache;
     },
 
+    /**
+     * @todo
+     */
+    _copyObject: function(object) {
+        var outObject = {};
+        for (var p in object) {
+            outObject[p] = object[p];
+        }
+        return outObject;
+    },
+
+    _cropLength: function() {
+        if (this._snapshots.length <= this.$data.maxLength) {
+            return;
+        }
+
+        // Deallocate old blobs
+        for (var i = this._snapshots.length - 1; i >= this.$data.maxLength; --i) {
+            var snapshot = this._snapshots[i];
+            for (var id in snapshot.blobCache) {
+                this._blobsCount[id] -= 1;
+                if (this._blobsCount[id] <= 0) {
+                    this.$data.blobCache[id] = snapshot.blobCache[id];
+                    this._pm._removeBlobHard(id);
+                    delete this._blobsCount[id];
+                }
+            }
+        }
+
+        this._snapshots.length = this.$data.maxLength;
+    },
+
     // @todo
     // @return {Boolean}
     _onRemoveBlob: function(id) {
+        for (var i = 0; i < this._snapshots.length; ++i) {
+            for (var blobId in this._snapshots[i].blobCache) {
+                if (blobId === id) {
+                    return false;
+                }
+            }
+        }
+
         // Ok, it can be removed as it does not exist in our saved data
         return true;
     }

--- a/lib/History.js
+++ b/lib/History.js
@@ -1,24 +1,27 @@
 "use strict";
 
 var Class = require("abitbol");
+var serializer = require("abitbol-serializable/lib/serializer");
 
 /**
  * @class History
  * @constructor
- * @param {ProjectManager} projectManager
+ * @param {ProjectManager} pm
  * @param {Object} params
  * @param {Number} params.maxLength Max amount of snapshots.
  */
 var History = Class.$extend({
 
-    __init__: function(projectManager, params) {
-        if (!projectManager) {
+    __init__: function(pm, params) {
+        if (!pm) {
             throw new Error("History needs a project manager to bind to.");
         }
 
         // Initialisation
         params = params || {};
         this.$data.maxLength = params.maxLength || 0;
+
+        this._pm = pm;
         this._snapshots = [];
         this._pointer = -1;
     },
@@ -64,20 +67,75 @@ var History = Class.$extend({
      * @method snapshot
      */
     snapshot: function() {
-        throw new Error("Not implemented yet");
+        var snapshot = {};
+        snapshot.layers = serializer.objectSerializer(this._pm.layers);
+        this._snapshots.splice(0, this._pointer, snapshot);
+        this._pointer = 0;
+
+        if (this._snapshots.length > this.$data.maxLength) {
+            this._snapshots.length = this.$data.maxLength;
+        }
     },
 
     /**
      * Go backwards or forwards in history.
-     * Positive delta is forwards, negative is backwards.
+     * Positive delta is forwards, negative one is backwards.
      * This will change the current project to the saved version.
      *
      * @method go
      * @param {Number} delta
      */
     go: function(delta) {
-        delta = (delta !== undefined) ? delta : -1;
-        throw new Error("Not implemented yet");
+        delta = this.try(delta);
+        if (delta === 0) {
+            return;
+        }
+
+        this._pointer -= delta;
+        var snapshot = this._snapshots[this._pointer];
+
+        // We create create these looking tables to be efficient in searching
+        var structuresCache = this._getStructuresCache(this._pm);
+        var snapshotStructuresCache = this._getStructuresCache(snapshot);
+
+        // Remove all structures that should not exist
+        for (var id in structuresCache) {
+            if (!snapshotStructuresCache[id]) {
+                this._pm.removeStructure(structuresCache[id]);
+            }
+        }
+
+        // Add all structures that should exist
+        for (id in snapshotStructuresCache) {
+            if (!structuresCache[id]) {
+                this._pm.addStructure(serializer.objectUnserializer(snapshotStructuresCache[id]));
+            }
+        }
+
+        // Move structure to the layer they belong to and apply unserialized data
+        for (var layerName in snapshot.layers) {
+            var snapshotLayer = snapshot.layers[layerName];
+            for (var i = 0; i < snapshotLayer.length; i++) {
+                var snapshotStructure = snapshotLayer[i];
+                var structure = structuresCache[snapshotStructure.id];
+                var layer = structure.getLayer();
+
+                // Change the layer if moved
+                if (structure.$data._layerName !== layerName) {
+                    layer.splice(layer.indexOf(structure), 1);
+                    layer = this._pm.$data.layers[layerName];
+                    layer.push(structure);
+                    structure.$data._layerName = layerName;
+                }
+
+                // Apply structure data
+                // TODO This apply should become a diff that will occur only on properties that are different
+                structure.unserialize(snapshotStructure);
+            }
+        }
+
+        // Final reordering
+        // FIXME
     },
 
     /**
@@ -109,7 +167,20 @@ var History = Class.$extend({
      */
     try: function(delta) {
         delta = (delta !== undefined) ? delta : -1;
-        throw new Error("Not implemented yet");
+        if (this._pointer < 0) {
+            return 0;
+        }
+
+        if (delta > 0) {
+            if (delta > this._pointer) {
+                delta = this._pointer;
+            }
+        }
+        else if (-delta > (this._snapshots.length - this._pointer - 1)) {
+            delta = - (this._snapshots.length - this._pointer - 1);
+        }
+
+        return delta;
     },
 
     /**
@@ -118,7 +189,30 @@ var History = Class.$extend({
      * @method clear
      */
     clear: function() {
-        throw new Error("Not implemented yet");
+        this._snapshots.length = 0;
+        this._pointer = -1;
+    },
+
+    /**
+     * Construct structures cache.
+     * This object associate all structures' id to the structure object.
+     *
+     * @method _getStructuresCache
+     * @private
+     * @param {ProjectManager} pm
+     * @return {Object}
+     */
+    _getStructuresCache: function(pm) {
+        var cache = {};
+        for (var layerName in pm.layers) {
+            var layer = pm.layers[layerName];
+            for (var i = 0; i < layer.length; i++) {
+                var structure = layer[i];
+                cache[structure.id] = structure;
+            }
+        }
+
+        return cache;
     }
 
 });

--- a/lib/History.js
+++ b/lib/History.js
@@ -41,23 +41,11 @@ var History = Class.$extend({
      * Max amount of snapshots stored by the history.
      *
      * @property maxLength
+     * @readOnly
      * @type {Number}
      */
     getMaxLength: function() {
         return this.$data.maxLength;
-    },
-
-    setMaxLength: function(maxLength) {
-        this.$data.maxLength = maxLength;
-
-        // Remove older snapshots if any
-        if (this._snapshots.length > maxLength) {
-            var backIndex = Math.max(this._pointer + 1, maxLength);
-            var headIndex = backIndex - maxLength;
-            this._snapshots.splice(backIndex, this._snapshots.length);
-            this._snapshots.splice(0, headIndex);
-            this._pointer -= headIndex;
-        }
     },
 
     /**
@@ -228,7 +216,12 @@ var History = Class.$extend({
     },
 
     /**
-     * @todo
+     * Copy an object with shallow copy for its attribute.
+     *
+     * @method _copyObject
+     * @private
+     * @param {Object} object
+     * @return {Object}
      */
     _copyObject: function(object) {
         var outObject = {};
@@ -238,6 +231,12 @@ var History = Class.$extend({
         return outObject;
     },
 
+    /**
+     * Crop the snapshots array to the max length.
+     *
+     * @method _cropLength
+     * @private
+     */
     _cropLength: function() {
         if (this._snapshots.length <= this.$data.maxLength) {
             return;
@@ -259,19 +258,16 @@ var History = Class.$extend({
         this._snapshots.length = this.$data.maxLength;
     },
 
-    // @todo
-    // @return {Boolean}
+    /**
+     * Called whenever a blob is removed.
+     * Returns whether the blob id can be completely deleted.
+     *
+     * @method _onRemoveBlob
+     * @private
+     * @return {Boolean}
+     */
     _onRemoveBlob: function(id) {
-        for (var i = 0; i < this._snapshots.length; ++i) {
-            for (var blobId in this._snapshots[i].blobCache) {
-                if (blobId === id) {
-                    return false;
-                }
-            }
-        }
-
-        // Ok, it can be removed as it does not exist in our saved data
-        return true;
+        return !this._blobsCount[id];
     }
 
 });

--- a/lib/History.js
+++ b/lib/History.js
@@ -17,6 +17,9 @@ var History = Class.$extend({
             throw new Error("History needs a project manager to bind to.");
         }
 
+        // Add soft blob removal to project
+        pm._removeBlobHook = this._onRemoveBlob;
+
         // Initialisation
         params = params || {};
         this.$data.maxLength = params.maxLength || 0;
@@ -24,6 +27,13 @@ var History = Class.$extend({
         this._pm = pm;
         this._snapshots = [];
         this._pointer = -1;
+    },
+
+    /**
+     * Destructor.
+     */
+    destroy: function() {
+        this._pm._removeBlobHook = null;
     },
 
     /**
@@ -205,6 +215,13 @@ var History = Class.$extend({
         }
 
         return cache;
+    },
+
+    // @todo
+    // @return {Boolean}
+    _onRemoveBlob: function(id) {
+        // Ok, it can be removed as it does not exist in our saved data
+        return true;
     }
 
 });

--- a/lib/History.js
+++ b/lib/History.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var Class = require("abitbol");
+var lodash = require("lodash");
 var serializer = require("abitbol-serializable/lib/serializer");
 
 /**
@@ -68,8 +69,8 @@ var History = Class.$extend({
     snapshot: function() {
         var snapshot = {};
         snapshot.layers = serializer.objectSerializer(this._pm.layers);
-        snapshot.blobCache = this._copyObject(this._pm.$data.blobCache);
-        snapshot.blobList = this._copyObject(this._pm.$data.wprjFile.$data.blobs);
+        snapshot.blobCache = lodash.clone(this._pm.$data.blobCache);
+        snapshot.blobList = lodash.clone(this._pm.$data.wprjFile.$data.blobs);
         this._snapshots.splice(0, this._pointer, snapshot);
         this._pointer = 0;
 
@@ -99,8 +100,8 @@ var History = Class.$extend({
         var snapshot = this._snapshots[this._pointer];
 
         // Reapplying blobs
-        this._pm.$data.wprjFile.$data.blobs = this._copyObject(snapshot.blobList);
-        this._pm.$data.blobCache = this._copyObject(snapshot.blobCache);
+        this._pm.$data.wprjFile.$data.blobs = lodash.clone(snapshot.blobList);
+        this._pm.$data.blobCache = lodash.clone(snapshot.blobCache);
 
         // We create these looking tables to be efficient in searching
         var structuresCache = this._pm.$data.structures;
@@ -213,22 +214,6 @@ var History = Class.$extend({
         }
 
         return cache;
-    },
-
-    /**
-     * Copy an object with shallow copy for its attribute.
-     *
-     * @method _copyObject
-     * @private
-     * @param {Object} object
-     * @return {Object}
-     */
-    _copyObject: function(object) {
-        var outObject = {};
-        for (var p in object) {
-            outObject[p] = object[p];
-        }
-        return outObject;
     },
 
     /**

--- a/lib/ProjectManager.js
+++ b/lib/ProjectManager.js
@@ -32,6 +32,8 @@ var ProjectManager = SerializableClass.$extend({
         this.$data.structures = {};
         this.$data.blobCache = {};   // {uuid: {blob: Blob, url: String}}
 
+        this._removeBlobHook = null;
+
         this.newEmptyProject();
         this.$super(params);
     },
@@ -444,20 +446,29 @@ var ProjectManager = SerializableClass.$extend({
 
     removeBlob: function(id) {
         this.$data.wprjFile.removeBlob(id);
-        // Free blobs and blobs' URL
+
         if (this.$data.blobCache[id]) {
-            if (this.$data.blobCache[id].url) {
-                (global.URL || global.webkitURL).revokeObjectURL(this.$data.blobCache[id].url);
+            if (!this._removeBlobHook || this._removeBlobHook(id)) {
+                this._removeBlobHard(id);
+            } else {
+                delete this.$data.blobCache[id];
             }
-            if (this.$data.blobCache[id].blob && this.$data.blobCache[id].blob.close) {
-                try {
-                    this.$data.blobCache[id].blob.close();
-                } catch (error) {
-                    // pass
-                }
-            }
-            delete this.$data.blobCache[id];
         }
+    },
+
+    _removeBlobHard: function(id) {
+        // Free blobs and blobs' URL
+        if (this.$data.blobCache[id].url) {
+            (global.URL || global.webkitURL).revokeObjectURL(this.$data.blobCache[id].url);
+        }
+        if (this.$data.blobCache[id].blob && this.$data.blobCache[id].blob.close) {
+            try {
+                this.$data.blobCache[id].blob.close();
+            } catch (error) {
+                // pass
+            }
+        }
+        delete this.$data.blobCache[id];
     },
 
     getBlobList: function() {

--- a/lib/ProjectManager.js
+++ b/lib/ProjectManager.js
@@ -1,11 +1,6 @@
 "use strict";
 
-// TODO Canvas
 // TODO DEFAULT METADATA {version: String, uuid: String, creationDate: Number, lastModification: Number}
-// TODO History
-// TODO Versioning
-// TODO Local Save (localStorage + IndexedDB)
-// TODO Move structure to front/back
 
 var ObsidianProjectFile = require("obsidian-file");
 var uuid = require("uuid");

--- a/test/History.js
+++ b/test/History.js
@@ -153,8 +153,8 @@ describe("History", function() {
             expectLayer(project.layers.l0, defaultProject.layers.l0);
             expectLayer(project.layers.l1, defaultProject.layers.l1);
             expectLayer(project.layers.l2, defaultProject.layers.l2);
-            expect(history.try(-5)).to.be.equal(0);
-            expect(history.try(5)).to.be.equal(1);
+            expect(history.simulate(-5)).to.be.equal(0);
+            expect(history.simulate(5)).to.be.equal(1);
 
             history.forward();
             expectLayer(project.layers.l0, defaultProject.layers.l0);
@@ -162,15 +162,15 @@ describe("History", function() {
             expect(project.layers.l1[0].x).to.be.equal("1_0b");
             expect(project.layers.l1[1].x).to.be.eql(defaultProject.layers.l1[1].x);
             expectLayer(project.layers.l2, defaultProject.layers.l2);
-            expect(history.try(-5)).to.be.equal(-1);
-            expect(history.try(5)).to.be.equal(0);
+            expect(history.simulate(-5)).to.be.equal(-1);
+            expect(history.simulate(5)).to.be.equal(0);
 
             history.go(-2); // Too far!
             expectLayer(project.layers.l0, defaultProject.layers.l0);
             expectLayer(project.layers.l1, defaultProject.layers.l1);
             expectLayer(project.layers.l2, defaultProject.layers.l2);
-            expect(history.try(-5)).to.be.equal(0);
-            expect(history.try(5)).to.be.equal(1);
+            expect(history.simulate(-5)).to.be.equal(0);
+            expect(history.simulate(5)).to.be.equal(1);
         });
 
         it("deletes old snapshots automatically", function() {
@@ -195,7 +195,7 @@ describe("History", function() {
             expect(project.layers.l1[0].x).to.be.equal("1_0_3");
             expect(project.layers.l1[1].x).to.be.eql(defaultProject.layers.l1[1].x);
             expectLayer(project.layers.l2, defaultProject.layers.l2);
-            expect(history.try(-1)).to.be.equal(0);
+            expect(history.simulate(-1)).to.be.equal(0);
         });
 
         it("deletes branched snapshots automatically", function() {
@@ -214,7 +214,7 @@ describe("History", function() {
             expectLayer(project.layers.l1, defaultProject.layers.l1);
             expectLayer(project.layers.l2, defaultProject.layers.l2);
             expect(history.length).to.be(3);
-            expect(history.try(1)).to.be(0);
+            expect(history.simulate(1)).to.be(0);
         });
 
     });

--- a/test/History.js
+++ b/test/History.js
@@ -23,17 +23,33 @@ var OwnStructure = Structure.$extend({
 
 Structure.$register(OwnStructure);
 
-var defaultPM = new ProjectManager();
-defaultPM.addStructure(new OwnStructure({ x: "0_0" }), "l0");
-defaultPM.addStructure(new OwnStructure({ x: "0_1" }), "l0");
-defaultPM.addStructure(new OwnStructure({ x: "0_2" }), "l0");
-defaultPM.addStructure(new OwnStructure({ x: "1_0" }), "l1");
-defaultPM.addStructure(new OwnStructure({ x: "1_1" }), "l1");
-defaultPM.addStructure(new OwnStructure({ x: "2_0" }), "l2");
+var project;
+var defaultProject = new ProjectManager();
+defaultProject.addStructure(new OwnStructure({ x: "0_0" }), "l0");
+defaultProject.addStructure(new OwnStructure({ x: "0_1" }), "l0");
+defaultProject.addStructure(new OwnStructure({ x: "0_2" }), "l0");
+defaultProject.addStructure(new OwnStructure({ x: "1_0" }), "l1");
+defaultProject.addStructure(new OwnStructure({ x: "1_1" }), "l1");
+defaultProject.addStructure(new OwnStructure({ x: "2_0" }), "l2");
 
-var pm;
-pm = new ProjectManager();
-pm.unserialize(defaultPM.serialize());
+var buffer = new Buffer([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+    0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x10,
+    0x02, 0x03, 0x00, 0x00, 0x00, 0x62, 0x9d, 0x17, 0xf2, 0x00, 0x00, 0x00,
+    0x09, 0x50, 0x4c, 0x54, 0x45, 0x00, 0x00, 0x00, 0xff, 0x00, 0x00, 0xff,
+    0xff, 0xff, 0x67, 0x19, 0x64, 0x1e, 0x00, 0x00, 0x00, 0x01, 0x62, 0x4b,
+    0x47, 0x44, 0x00, 0x88, 0x05, 0x1d, 0x48, 0x00, 0x00, 0x00, 0x09, 0x70,
+    0x48, 0x59, 0x73, 0x00, 0x00, 0x0e, 0xc4, 0x00, 0x00, 0x0e, 0xc4, 0x01,
+    0x95, 0x2b, 0x0e, 0x1b, 0x00, 0x00, 0x00, 0x07, 0x74, 0x49, 0x4d, 0x45,
+    0x07, 0xdf, 0x0b, 0x12, 0x0d, 0x0b, 0x17, 0xca, 0x83, 0x65, 0x00, 0x00,
+    0x00, 0x00, 0x3d, 0x49, 0x44, 0x41, 0x54, 0x08, 0x1d, 0x0d, 0xc1, 0xc1,
+    0x0d, 0x00, 0x21, 0x0c, 0x03, 0xc1, 0x2d, 0x07, 0xd1, 0x0f, 0xfd, 0x9c,
+    0xf2, 0x8a, 0x5c, 0x05, 0xf2, 0x0b, 0xa5, 0xca, 0xf3, 0x0c, 0x27, 0x98,
+    0xe0, 0xf3, 0x15, 0x6e, 0x15, 0x2e, 0x0b, 0xeb, 0x09, 0xdf, 0x32, 0x13,
+    0x4c, 0x50, 0x7a, 0x43, 0xeb, 0x0d, 0xa5, 0xb5, 0xe9, 0x6e, 0x51, 0x5a,
+    0x9b, 0x09, 0x4e, 0xfc, 0x91, 0x4d, 0x22, 0x7f, 0x72, 0xcc, 0xb0, 0x7f,
+    0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82
+]);
 
 function expectLayer(layer1, layer2) {
     expect(layer1).to.have.length(layer2.length);
@@ -47,25 +63,25 @@ function expectLayer(layer1, layer2) {
 describe("History", function() {
 
     beforeEach(function() {
-        pm = new ProjectManager();
-        pm.unserialize(defaultPM.serialize());
+        project = new ProjectManager();
+        project.unserialize(defaultProject.serialize());
     });
 
     describe("LENGTH", function() {
 
         it("can set max length", function() {
-            var history = new History(pm);
+            var history = new History(project);
             expect(history.maxLength).to.equal(0);
 
             history.maxLength = 5;
             expect(history.maxLength).to.equal(5);
 
-            var history2 = new History(pm, { maxLength: 3 });
+            var history2 = new History(project, { maxLength: 3 });
             expect(history2.maxLength).to.equal(3);
         });
 
         it("is increased up to max length", function() {
-            var history = new History(pm, { maxLength: 3 });
+            var history = new History(project, { maxLength: 3 });
             expect(history.length).to.equal(0);
 
             history.snapshot();
@@ -78,7 +94,7 @@ describe("History", function() {
         });
 
         it("keeps max length the same", function() {
-            var history = new History(pm, { maxLength: 3 });
+            var history = new History(project, { maxLength: 3 });
             expect(history.maxLength).to.equal(3);
 
             history.snapshot();
@@ -91,7 +107,7 @@ describe("History", function() {
         });
 
         it("removes old snapshots when max length is changed", function() {
-            var history = new History(pm, { maxLength: 3 });
+            var history = new History(project, { maxLength: 3 });
             expect(history.maxLength).to.equal(3);
             history.snapshot();
             history.snapshot();
@@ -104,102 +120,102 @@ describe("History", function() {
 
     });
 
-    describe("NAVIGATING", function() {
+    describe("STRUCTURES", function() {
 
         it("can go back", function() {
-            var history = new History(pm, { maxLength: 5 });
+            var history = new History(project, { maxLength: 5 });
             history.snapshot();
 
-            pm.layers.l1[0].x = "1_0b";
+            project.layers.l1[0].x = "1_0b";
             history.snapshot();
 
-            expect(pm.layers).to.only.have.keys("l0", "l1", "l2");
-            expectLayer(pm.layers.l0, defaultPM.layers.l0);
-            expect(pm.layers.l1).to.have.length(defaultPM.layers.l1.length);
-            expect(pm.layers.l1[0].x).to.be.equal("1_0b");
-            expect(pm.layers.l1[1].x).to.be.eql(defaultPM.layers.l1[1].x);
-            expectLayer(pm.layers.l2, defaultPM.layers.l2);
+            expect(project.layers).to.only.have.keys("l0", "l1", "l2");
+            expectLayer(project.layers.l0, defaultProject.layers.l0);
+            expect(project.layers.l1).to.have.length(defaultProject.layers.l1.length);
+            expect(project.layers.l1[0].x).to.be.equal("1_0b");
+            expect(project.layers.l1[1].x).to.be.eql(defaultProject.layers.l1[1].x);
+            expectLayer(project.layers.l2, defaultProject.layers.l2);
 
             history.back();
-            expectLayer(pm.layers.l0, defaultPM.layers.l0);
-            expectLayer(pm.layers.l1, defaultPM.layers.l1);
-            expectLayer(pm.layers.l2, defaultPM.layers.l2);
+            expectLayer(project.layers.l0, defaultProject.layers.l0);
+            expectLayer(project.layers.l1, defaultProject.layers.l1);
+            expectLayer(project.layers.l2, defaultProject.layers.l2);
         });
 
         it("can go back and forth", function() {
-            var history = new History(pm, { maxLength: 5 });
+            var history = new History(project, { maxLength: 5 });
             history.snapshot();
 
-            pm.layers.l1[0].x = "1_0b";
+            project.layers.l1[0].x = "1_0b";
             history.snapshot();
 
             history.back();
             history.forward();
-            expectLayer(pm.layers.l0, defaultPM.layers.l0);
-            expect(pm.layers.l1).to.have.length(defaultPM.layers.l1.length);
-            expect(pm.layers.l1[0].x).to.be.equal("1_0b");
-            expect(pm.layers.l1[1].x).to.be.eql(defaultPM.layers.l1[1].x);
-            expectLayer(pm.layers.l2, defaultPM.layers.l2);
+            expectLayer(project.layers.l0, defaultProject.layers.l0);
+            expect(project.layers.l1).to.have.length(defaultProject.layers.l1.length);
+            expect(project.layers.l1[0].x).to.be.equal("1_0b");
+            expect(project.layers.l1[1].x).to.be.eql(defaultProject.layers.l1[1].x);
+            expectLayer(project.layers.l2, defaultProject.layers.l2);
         });
 
         it("won't go too far", function() {
-            var history = new History(pm, { maxLength: 5 });
+            var history = new History(project, { maxLength: 5 });
             history.snapshot();
-            pm.layers.l1[0].x = "1_0b";
+            project.layers.l1[0].x = "1_0b";
             history.snapshot();
 
             history.back();
             history.back(); // Too far!
-            expectLayer(pm.layers.l0, defaultPM.layers.l0);
-            expectLayer(pm.layers.l1, defaultPM.layers.l1);
-            expectLayer(pm.layers.l2, defaultPM.layers.l2);
+            expectLayer(project.layers.l0, defaultProject.layers.l0);
+            expectLayer(project.layers.l1, defaultProject.layers.l1);
+            expectLayer(project.layers.l2, defaultProject.layers.l2);
             expect(history.try(-5)).to.be.equal(0);
             expect(history.try(5)).to.be.equal(1);
 
             history.forward();
-            expectLayer(pm.layers.l0, defaultPM.layers.l0);
-            expect(pm.layers.l1).to.have.length(defaultPM.layers.l1.length);
-            expect(pm.layers.l1[0].x).to.be.equal("1_0b");
-            expect(pm.layers.l1[1].x).to.be.eql(defaultPM.layers.l1[1].x);
-            expectLayer(pm.layers.l2, defaultPM.layers.l2);
+            expectLayer(project.layers.l0, defaultProject.layers.l0);
+            expect(project.layers.l1).to.have.length(defaultProject.layers.l1.length);
+            expect(project.layers.l1[0].x).to.be.equal("1_0b");
+            expect(project.layers.l1[1].x).to.be.eql(defaultProject.layers.l1[1].x);
+            expectLayer(project.layers.l2, defaultProject.layers.l2);
             expect(history.try(-5)).to.be.equal(-1);
             expect(history.try(5)).to.be.equal(0);
 
             history.go(-2); // Too far!
-            expectLayer(pm.layers.l0, defaultPM.layers.l0);
-            expectLayer(pm.layers.l1, defaultPM.layers.l1);
-            expectLayer(pm.layers.l2, defaultPM.layers.l2);
+            expectLayer(project.layers.l0, defaultProject.layers.l0);
+            expectLayer(project.layers.l1, defaultProject.layers.l1);
+            expectLayer(project.layers.l2, defaultProject.layers.l2);
             expect(history.try(-5)).to.be.equal(0);
             expect(history.try(5)).to.be.equal(1);
         });
 
         it("deletes old snapshots automatically", function() {
-            var history = new History(pm, { maxLength: 5 });
-            pm.layers.l1[0].x = "1_0_1";
+            var history = new History(project, { maxLength: 5 });
+            project.layers.l1[0].x = "1_0_1";
             history.snapshot();
-            pm.layers.l1[0].x = "1_0_2";
+            project.layers.l1[0].x = "1_0_2";
             history.snapshot();
-            pm.layers.l1[0].x = "1_0_3";
+            project.layers.l1[0].x = "1_0_3";
             history.snapshot();
-            pm.layers.l1[0].x = "1_0_4";
+            project.layers.l1[0].x = "1_0_4";
             history.snapshot();
-            pm.layers.l1[0].x = "1_0_5";
+            project.layers.l1[0].x = "1_0_5";
             history.snapshot();
-            pm.layers.l1[0].x = "1_0_6";
+            project.layers.l1[0].x = "1_0_6";
             history.snapshot();
-            pm.layers.l1[0].x = "1_0_7";
+            project.layers.l1[0].x = "1_0_7";
             history.snapshot();
 
             history.go(-4);
-            expectLayer(pm.layers.l0, defaultPM.layers.l0);
-            expect(pm.layers.l1[0].x).to.be.equal("1_0_3");
-            expect(pm.layers.l1[1].x).to.be.eql(defaultPM.layers.l1[1].x);
-            expectLayer(pm.layers.l2, defaultPM.layers.l2);
+            expectLayer(project.layers.l0, defaultProject.layers.l0);
+            expect(project.layers.l1[0].x).to.be.equal("1_0_3");
+            expect(project.layers.l1[1].x).to.be.eql(defaultProject.layers.l1[1].x);
+            expectLayer(project.layers.l2, defaultProject.layers.l2);
             expect(history.try(-1)).to.be.equal(0);
         });
 
         it("deletes branched snapshots automatically", function() {
-            var history = new History(pm, { maxLength: 5 });
+            var history = new History(project, { maxLength: 5 });
             history.snapshot();
             history.snapshot();
             history.snapshot();
@@ -210,9 +226,9 @@ describe("History", function() {
             expect(history.length).to.be(4);
 
             history.snapshot();
-            expectLayer(pm.layers.l0, defaultPM.layers.l0);
-            expectLayer(pm.layers.l1, defaultPM.layers.l1);
-            expectLayer(pm.layers.l2, defaultPM.layers.l2);
+            expectLayer(project.layers.l0, defaultProject.layers.l0);
+            expectLayer(project.layers.l1, defaultProject.layers.l1);
+            expectLayer(project.layers.l2, defaultProject.layers.l2);
             expect(history.length).to.be(3);
             expect(history.try(1)).to.be(0);
         });
@@ -222,27 +238,75 @@ describe("History", function() {
     describe("ORDER", function() {
 
         it("moves structures back to their correct layer", function() {
-            var history = new History(pm, { maxLength: 5 });
+            var history = new History(project, { maxLength: 5 });
             history.snapshot();
-            pm.setStructureLayer(pm.layers.l0[0], "l3");
+            project.setStructureLayer(project.layers.l0[0], "l3");
             history.snapshot();
 
             history.back();
-            expectLayer(pm.layers.l0, defaultPM.layers.l0);
-            expectLayer(pm.layers.l1, defaultPM.layers.l1);
-            expectLayer(pm.layers.l2, defaultPM.layers.l2);
+            expectLayer(project.layers.l0, defaultProject.layers.l0);
+            expectLayer(project.layers.l1, defaultProject.layers.l1);
+            expectLayer(project.layers.l2, defaultProject.layers.l2);
         });
 
         it("moves structures within its layer", function() {
-            var history = new History(pm, { maxLength: 5 });
+            var history = new History(project, { maxLength: 5 });
             history.snapshot();
-            pm.setStructureIndex(pm.layers.l0[0], 1);
+            project.setStructureIndex(project.layers.l0[0], 1);
             history.snapshot();
 
             history.back();
-            expectLayer(pm.layers.l0, defaultPM.layers.l0);
-            expectLayer(pm.layers.l1, defaultPM.layers.l1);
-            expectLayer(pm.layers.l2, defaultPM.layers.l2);
+            expectLayer(project.layers.l0, defaultProject.layers.l0);
+            expectLayer(project.layers.l1, defaultProject.layers.l1);
+            expectLayer(project.layers.l2, defaultProject.layers.l2);
+        });
+
+    });
+
+    describe("BLOBS", function() {
+
+        it.skip("can revert blobs", function() {
+            var history = new History(project, { maxLength: 5 });
+            history.snapshot();
+
+            var id = project.addBlobFromBuffer(buffer);
+            expect(project.$data.wprjFile.getBlob(id)).to.be(buffer);
+            history.snapshot();
+
+            history.back();
+            expect(project.$data.wprjFile.getBlob(id)).to.be(null);
+
+            history.forward();
+            expect(project.$data.wprjFile.getBlob(id)).to.be(buffer);
+
+            project.removeBlob(id);
+            expect(project.$data.wprjFile.getBlob(id)).to.be(null);
+            history.snapshot();
+
+            history.back();
+            expect(project.$data.wprjFile.getBlob(id)).to.be(buffer);
+        });
+
+        it.skip("closes old blobs automatically", function() {
+            var history = new History(project, { maxLength: 2 });
+            var id = project.addBlobFromBuffer(buffer);
+            var blob = project.getBlob(id);
+            history.snapshot();
+
+            project.removeBlob(id);
+            history.snapshot();
+            expect(blob.isClosed).to.be(false);
+
+            history.snapshot();
+            expect(blob.isClosed).to.be(true);
+        });
+
+        it.skip("closes blobs never seen in snapshots", function() {
+            var history = new History(project, { maxLength: 5 });
+            var id = project.addBlobFromBuffer(buffer);
+            var blob = project.getBlob(id);
+            project.removeBlob(id);
+            expect(blob.isClosed).to.be(true);
         });
 
     });
@@ -250,7 +314,7 @@ describe("History", function() {
     describe("CLEAR", function() {
 
         it("removes everything", function() {
-            var history = new History(pm, { maxLength: 5 });
+            var history = new History(project, { maxLength: 5 });
             history.snapshot();
             history.snapshot();
             history.snapshot();

--- a/test/History.js
+++ b/test/History.js
@@ -219,6 +219,34 @@ describe("History", function() {
 
     });
 
+    describe("ORDER", function() {
+
+        it("moves structures back to their correct layer", function() {
+            var history = new History(pm, { maxLength: 5 });
+            history.snapshot();
+            pm.setStructureLayer(pm.layers.l0[0], "l3");
+            history.snapshot();
+
+            history.back();
+            expectLayer(pm.layers.l0, defaultPM.layers.l0);
+            expectLayer(pm.layers.l1, defaultPM.layers.l1);
+            expectLayer(pm.layers.l2, defaultPM.layers.l2);
+        });
+
+        it("moves structures within its layer", function() {
+            var history = new History(pm, { maxLength: 5 });
+            history.snapshot();
+            pm.setStructureIndex(pm.layers.l0[0], 1);
+            history.snapshot();
+
+            history.back();
+            expectLayer(pm.layers.l0, defaultPM.layers.l0);
+            expectLayer(pm.layers.l1, defaultPM.layers.l1);
+            expectLayer(pm.layers.l2, defaultPM.layers.l2);
+        });
+
+    });
+
     describe("CLEAR", function() {
 
         it("removes everything", function() {

--- a/test/History.js
+++ b/test/History.js
@@ -1,0 +1,163 @@
+"use strict";
+
+var expect = require("expect.js");
+var History = require("../lib/History.js");
+
+describe("History", function() {
+
+    it("can set level", function() {
+        var history = new History();
+        expect(history.level).to.equal(0);
+
+        history.level = 5;
+        expect(history.level).to.equal(5);
+
+        var history2 = new History({ level: 7 });
+        expect(history2.level).to.equal(7);
+    });
+
+    it.skip("can save snapshots", function() {
+        var history = new History({ level: 5 });
+        expect(history.snapshotsCount).to.equal(0);
+
+        history.saveSnapshot({ x: 1, z: 1 });
+        history.saveSnapshot({ x: 2, y: 2 });
+        history.saveSnapshot({ x: 3 });
+        expect(history.snapshotsCount).to.equal(3);
+    });
+
+    it.skip("can undo snapshots", function() {
+        var history = new History({ level: 5 });
+        history.saveSnapshot({ x: 1, z: 1 });
+        history.saveSnapshot({ x: 2, y: 2 });
+        history.saveSnapshot({ x: 3 });
+
+        var snapshot = history.undoSnapshot();
+        expect(snapshot).to.only.have.keys(["x", "y"]);
+        expect(snapshot.x).to.equal(2);
+        expect(snapshot.y).to.equal(2);
+
+        snapshot = history.undoSnapshot();
+        expect(snapshot).to.only.have.keys(["x", "z"]);
+        expect(snapshot.x).to.equal(1);
+        expect(snapshot.z).to.equal(1);
+    });
+
+    it.skip("can undo multiple snapshots at once", function() {
+        var history = new History({ level: 5 });
+        history.saveSnapshot({ x: 1, z: 1 });
+        history.saveSnapshot({ x: 2, y: 2 });
+        history.saveSnapshot({ x: 3 });
+
+        var snapshot = history.undoSnapshot(2);
+        expect(snapshot).to.only.have.keys(["x", "z"]);
+        expect(snapshot.x).to.equal(1);
+        expect(snapshot.z).to.equal(1);
+    });
+
+    it.skip("can redo snapshots", function() {
+        var history = new History({ level: 5 });
+        history.saveSnapshot({ x: 1, z: 1 });
+        history.saveSnapshot({ x: 2, y: 2 });
+        history.saveSnapshot({ x: 3 });
+        history.undoSnapshot(2);
+
+        var snapshot = history.redoSnapshot();
+        expect(snapshot).to.only.have.keys(["x", "y"]);
+        expect(snapshot.x).to.equal(2);
+        expect(snapshot.y).to.equal(2);
+
+        snapshot = history.redoSnapshot();
+        expect(snapshot).to.only.have.keys(["x"]);
+        expect(snapshot.x).to.equal(3);
+    });
+
+    it.skip("can redo multiple snapshots at once", function() {
+        var history = new History({ level: 5 });
+        history.saveSnapshot({ x: 1, z: 1 });
+        history.saveSnapshot({ x: 2, y: 2 });
+        history.saveSnapshot({ x: 3 });
+        history.undoSnapshot(2);
+
+        var snapshot = history.redoSnapshot(2);
+        expect(snapshot).to.only.have.keys(["x", "y"]);
+        expect(snapshot.x).to.equal(2);
+        expect(snapshot.y).to.equal(2);
+    });
+
+    it.skip("can get current snapshot", function() {
+        var history = new History({ level: 5 });
+        history.saveSnapshot({ x: 1 });
+        history.saveSnapshot({ x: 2, y: 2 });
+        history.saveSnapshot({ x: 3 });
+
+        var snapshot = history.getSnapshot();
+        expect(snapshot).to.only.have.key("x");
+        expect(snapshot.x).to.equal(3);
+
+        history.undoSnapshot();
+        snapshot = history.getSnapshot();
+        expect(snapshot).to.only.have.keys(["x", "y"]);
+        expect(snapshot.x).to.equal(2);
+        expect(snapshot.y).to.equal(2);
+
+        history.redoSnapshot();
+        snapshot = history.getSnapshot();
+        expect(snapshot).to.only.have.key("x");
+        expect(snapshot.x).to.equal(3);
+    });
+
+    it.skip("can clear all snapshots", function() {
+        var history = new History({ level: 5 });
+        history.saveSnapshot({ x: 1 });
+        history.saveSnapshot({ x: 2, y: 2 });
+        history.saveSnapshot({ x: 3 });
+
+        history.clearSnapshots();
+        var snapshot = history.getSnapshot();
+        expect(snapshot).to.equal(null);
+        expect(history.snapshotsCount).to.equal(0);
+    });
+
+    it.skip("deletes old snapshots automatically", function() {
+        var history = new History({ level: 2 });
+        history.saveSnapshot({ x: 1, z: 1 });
+        history.saveSnapshot({ x: 2, y: 2 });
+        history.saveSnapshot({ x: 3 });
+
+        var snapshot = history.undoSnapshot();
+        expect(snapshot).to.only.have.keys(["x", "y"]);
+        expect(snapshot.x).to.equal(2);
+        expect(snapshot.y).to.equal(2);
+
+        snapshot = history.undoSnapshot();
+        expect(snapshot).to.equal(null);
+    });
+
+    it.skip("deletes branched snapshots automatically", function() {
+        var history = new History({ level: 5 });
+        history.saveSnapshot({ x: 1, z: 1 });
+        history.saveSnapshot({ x: 2, y: 2 });
+        history.saveSnapshot({ x: 3 });
+        history.saveSnapshot({ x: 4, y: 4, z: 4 });
+        history.saveSnapshot({ y: 5 });
+
+        history.undoSnapshot(3);
+        history.saveSnapshot({ y: 6, z: 6 });
+        expect(history.snapshotsCount).to.equal(3);
+
+        var snapshot = history.getSnapshot();
+        expect(snapshot).to.only.have.keys(["y", "z"]);
+        expect(snapshot.y).to.equal(6);
+        expect(snapshot.z).to.equal(6);
+
+        snapshot = history.redoSnapshot();
+        expect(snapshot).to.equal(null);
+
+        snapshot = history.undoSnapshot();
+        expect(snapshot).to.only.have.keys(["x", "y"]);
+        expect(snapshot.x).to.equal(2);
+        expect(snapshot.y).to.equal(2);
+    });
+
+});

--- a/test/History.js
+++ b/test/History.js
@@ -72,9 +72,6 @@ describe("History", function() {
             var history = new History(project);
             expect(history.maxLength).to.equal(0);
 
-            history.maxLength = 5;
-            expect(history.maxLength).to.equal(5);
-
             var history2 = new History(project, { maxLength: 3 });
             expect(history2.maxLength).to.equal(3);
         });
@@ -103,18 +100,6 @@ describe("History", function() {
             history.snapshot();
             history.snapshot();
             expect(history.maxLength).to.equal(3);
-        });
-
-        it("removes old snapshots when max length is changed", function() {
-            var history = new History(project, { maxLength: 3 });
-            expect(history.maxLength).to.equal(3);
-            history.snapshot();
-            history.snapshot();
-            expect(history.maxLength).to.equal(3);
-
-            history.maxLength = 1;
-            expect(history.maxLength).to.equal(1);
-            expect(history.length).to.equal(1);
         });
 
     });


### PR DESCRIPTION
Closes #6 

# obsidian-project: History

`History` is a class that helps managing over-time changes of a project. Features:

* A run-time history binded to a specific project-manager.
* Take snapshots of the current state of a project.
* Go back and forth into the history.
* Changes are applied through a diff, so only properties that have changed are reset.

Example:

```javascript
var History = require("obsidian-project/lib/History");

var history = new History(project, {
    maxLength: 20   // How many snapshots at most (depth of the history stack)
});

history.snapshot(); // Save initial state of our project

// Our project changes, we save this new state
project.addStructure(structure, "foo");
structure.x = 42;
history.snapshot();

history.back();     // Revert back to initial state (structure not in project)
history.forward();  // Cancel revert (structure.x is now 42)
```


## Snapshots

Taking snapshots is at the heart of the History. This is up to the developer to do a `history.snapshot()` whenever a significant change has occured across the project.

```javascript
history.snapshot();
history.clear();    // Remove all stored snapshots 
```

__NOTE:__ Project metadata are not saved into the snapshots. Blobs are only saved as references, and therefore any changes to their inner data are not stored.


## Navigating

```javascript
history.back();
history.forward();
history.go(-3);     // Similar in result to three history.back() in a row
history.go(4);      // Similar in result to four history.forward() in a row
```
