### PR TITLE
Versioning implementation

### DIFF
--- a/doc/ProjectManager.md
+++ b/doc/ProjectManager.md
@@ -6,10 +6,8 @@
 * Load a save project from a WPRJ file,
 * Projects can have metadata,
 * Projects can have attached resources Blob (images, texts, video, 3D Models,...),
-* TODO ~~Can handle canvas as resource (with history management)~~
-* TODO ~~History management (undo/redo)~~
-* TODO ~~Versionning (apply filters to old projects versions to update them)~~
-* TODO ~~Local save (to allow data recovery on browser crash)~~
+* History management (see `History` class)
+* Versioning (apply filters to old projects in order to update them)
 
 Example:
 
@@ -320,3 +318,25 @@ project.getBlobAsImage("blobId")
 project.getBlobList();  // -> ["blobId1", "blobId2", ...]
 ```
 
+
+## Versioning
+
+One can add a functions to convert project during opening. Example:
+
+```javascript
+// In this example, since version 1.5.0, MyStructure.name is renamed translatableName. And before 1.0.0, it didn't exist anyway.
+project.addVersionFilter(">=1.0.0 <1.5.0", "1.5.0", function(sProject) {
+    for (var i = 0; i < sProject.layers.myLayer.length; ++i) {
+        var structure = sProject.layers.myLayer[i];
+        if (structure.__name__ === "MyStructure") {
+             structure.translatableName = structure.name;
+             delete structure.name;
+        }
+    }
+    return sProject;
+});
+```
+
+* `sProject` is the project in its serialized form.
+
+__NOTE:__ If there is any ambiguity with filters (for instance, some overlaping), the behaviour is undefined.

--- a/doc/ProjectManager.md
+++ b/doc/ProjectManager.md
@@ -337,6 +337,15 @@ project.addVersionFilter(">=1.0.0 <1.5.0", "1.5.0", function(sProject) {
 });
 ```
 
-* `sProject` is the project in its serialized form.
+This uses the function:
 
-__NOTE:__ If there is any ambiguity with filters (for instance, some overlaping), the behaviour is undefined.
+```javascript
+addVersionFilter(sourceSemver, targetVersion, convert)
+```
+
+* `sourceSemver` a [semver](https://github.com/npm/node-semver) string.
+* `targetVersion` the resulting version after the conversion.
+* `convert` a `function(sProject)` callback where:
+  * `sProject` is the project in its serialized form.
+
+__NOTE:__ If there is any ambiguity with filters (for instance, some source versions overlaping), the behaviour is undefined.

--- a/lib/ProjectManager.js
+++ b/lib/ProjectManager.js
@@ -8,6 +8,7 @@ var Q = require("q");
 var SerializableClass = require("abitbol-serializable");
 var serializer = require("abitbol-serializable/lib/serializer");
 var httpRequest = require("obsidian-http-request");
+var semver = require("semver");
 
 var Structure = require("./Structure.js");
 var helpers = require("./helpers.js");
@@ -26,11 +27,29 @@ var ProjectManager = SerializableClass.$extend({
         this.$data.layers = {};
         this.$data.structures = {};
         this.$data.blobCache = {};   // {uuid: {blob: Blob, url: String}}
+        this.$data.version = "0.0.0";
 
+        this._filters = [];
         this._removeBlobHook = null;
 
         this.newEmptyProject();
         this.$super(params);
+    },
+
+    /**
+     * The version of the project.
+     *
+     * @property version
+     * @type String
+     * @default "0.0.0"
+     */
+    getVersion: function() {
+        "@serializable false";
+        return this.$data.version;
+    },
+
+    setVersion: function(version) {
+        this.$data.version = version;
     },
 
     getMimetype: function() {
@@ -243,6 +262,7 @@ var ProjectManager = SerializableClass.$extend({
 
     saveAsBuffer: function() {
         this.$data.wprjFile.project = this.serialize();
+        this.$data.wprjFile.metadata.version = this.$data.version;
         return this.$data.wprjFile.exportAsBlob();
     },
 
@@ -259,6 +279,7 @@ var ProjectManager = SerializableClass.$extend({
             throw new Error("UnvalidProject");
         }
         var wprjFile = new ObsidianProjectFile(buffer);
+        this._applyVersionFilters(wprjFile);
         this._clean();
         this.$data.wprjFile = wprjFile;
         this.unserialize(wprjFile.project);
@@ -478,6 +499,48 @@ var ProjectManager = SerializableClass.$extend({
         var serialized = this.$super();
         serialized.layers = serializer.objectSerializer(this.layers);
         return serialized;
+    },
+
+    /**
+     * Add a new filter to convert from a previous version.
+     *
+     * @method addVersionFilter
+     * @param {String} sourceSemver
+     * @param {String} targetVersion
+     * @param {Function} convert
+     */
+    addVersionFilter: function(sourceSemver, targetVersion, convert) {
+        this._filters.push({
+            sourceSemver: sourceSemver,
+            targetVersion: targetVersion,
+            convert: convert
+        });
+    },
+
+    /**
+     * Sequentially apply all filters until hitting the current version.
+     *
+     * @method _applyVersionFilters
+     * @private
+     * @param  {obsidian-file} wprjFile
+     */
+    _applyVersionFilters: function(wprjFile) {
+        if (!wprjFile.metadata.version) {
+            return;
+        }
+
+        var converted = true;
+        while (converted) {
+            converted = false;
+            for (var i = 0; i < this._filters.length; ++i) {
+                var filter = this._filters[i];
+                if (semver.lt(wprjFile.metadata.version, filter.targetVersion) && semver.satisfies(wprjFile.metadata.version, filter.sourceSemver)) {
+                    converted = true;
+                    wprjFile.project = filter.convert(wprjFile.project);
+                    wprjFile.metadata.version = filter.targetVersion;
+                }
+            }
+        }
     },
 
     unserialize: function(serialized) {

--- a/lib/ProjectManager.js
+++ b/lib/ProjectManager.js
@@ -109,6 +109,9 @@ var ProjectManager = SerializableClass.$extend({
         var wprjFile = new ObsidianProjectFile();
         if (this.$data.wprjFile) {
             wprjFile.type = this.$data.wprjFile.type;
+            wprjFile.metadata = {
+                version: this.$data.version
+            };
             this._clean();
         }
         if (metadata) {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "obsidian-http-request": "^1.1.0",
     "q": "^1.4.1",
     "request": "^2.67.0",
+    "semver": "^5.3.0",
     "uuid": "^2.0.1"
   },
   "devDependencies": {

--- a/test/ProjectManager.js
+++ b/test/ProjectManager.js
@@ -109,8 +109,8 @@ describe("ProjectManager", function() {
             project.addStructure(structure);
             var buffer = project.saveAsBuffer();
 
-            project.newEmptyProject();
             project.setVersion("1.0.0");
+            project.newEmptyProject();
             project.addVersionFilter("0.0.1", "0.4.0", function(sProject) {
                 expect(sProject.layers.default[0].id).to.be("structure-0");
                 sProject.layers.default[0].id = "structure-1";

--- a/test/ProjectManager.js
+++ b/test/ProjectManager.js
@@ -101,6 +101,39 @@ describe("ProjectManager", function() {
 
     });
 
+    describe("VERSIONING", function() {
+
+        it("can convert structures up to current version", function() {
+            var project = new ProjectManager({ version: "0.0.1" });
+            var structure = new Structure({ id: "structure-0" });
+            project.addStructure(structure);
+            var buffer = project.saveAsBuffer();
+
+            project.newEmptyProject();
+            project.setVersion("1.0.0");
+            project.addVersionFilter("0.0.1", "0.4.0", function(sProject) {
+                expect(sProject.layers.default[0].id).to.be("structure-0");
+                sProject.layers.default[0].id = "structure-1";
+                return sProject;
+            });
+            project.addVersionFilter(">=0.1.0 <0.3.0", "1.0.0", function(sProject) {
+                expect().fail();
+            });
+            project.addVersionFilter(">=0.1.0 >=0.3.0", "1.0.0", function(sProject) {
+                expect(sProject.layers.default[0].id).to.be("structure-1");
+                sProject.layers.default[0].id = "structure-2";
+                return sProject;
+            });
+            project.addVersionFilter("^0.9.0", "1.0.0", function(sProject) {
+                expect().fail();
+            });
+
+            project.openFromBuffer(buffer);
+            expect(project.layers.default[0].id).to.be("structure-2");
+        });
+
+    });
+
     describe("LAYERS", function() {
 
         it("can add one or more layers", function() {


### PR DESCRIPTION
Implements #7 

## Versioning

One can add a functions to convert project during opening. Example:

```javascript
// In this example, since version 1.5.0, MyStructure.name is renamed translatableName. And before 1.0.0, it didn't exist anyway.
project.addVersionFilter(">=1.0.0 <1.5.0", "1.5.0", function(sProject) {
    for (var i = 0; i < sProject.layers.myLayer.length; ++i) {
        var structure = sProject.layers.myLayer[i];
        if (structure.__name__ === "MyStructure") {
             structure.translatableName = structure.name;
             delete structure.name;
        }
    }
    return sProject;
});
```

* `sProject` is the project in its serialized form.

__NOTE:__ If there is any ambiguity with filters (for instance, some overlaping), the behaviour is undefined.