### PR TITLE
fix: type definition for ProjectManager

### DIFF
--- a/types/lib/project-manager.d.ts
+++ b/types/lib/project-manager.d.ts
@@ -17,7 +17,7 @@ export interface ProjectManagerOptions {
 }
 
 export class ProjectManager extends SerializableClass {
-    __name__: "Project";
+    __name__: string;
 
     __init__(params?: ProjectManagerOptions): void;
 


### PR DESCRIPTION
Little patch to be able to override the class in an ES6 compliant way